### PR TITLE
build: use own build-artifacts repo, stable artifact versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,34 +15,25 @@ ENV ETF_LOG_DIR /etf/logs
 
 ENV ETF_RELATIVE_URL etf-webapp
 
-# Possible values: “latest”, <version as MAJOR.MINOR.BUGFIX> e.g. “2.0.0” or
-# <version as MAJOR.MINOR> e.g. “1.0” to get the latest bugfix version
-ENV ETF_WEBAPP_VERSION latest
+# Possible values for *_VERSION:
+# <version as MAJOR.MINOR.BUGFIX> e.g. “2.0.0” or
+# <version as MAJOR.MINOR.BUGFIX-SNAPSHOT> e.g. “1.0.0-SNAPSHOT” to get the latest snapshot version
+ENV ETF_WEBAPP_VERSION next
 
-# Possible values: “latest”, <version as MAJOR.MINOR.BUGFIX> or
-# <version as MAJOR.MINOR>
 # Packed with the Webapp
-ENV ETF_TESTDRIVER_BSX_VERSION latest
+ENV ETF_TESTDRIVER_BSX_VERSION 2.0.1-SNAPSHOT
 
-# Possible values: “latest”, <version as MAJOR.MINOR.BUGFIX> or
-# <version as MAJOR.MINOR>
 # Will be downloaded
-ENV ETF_GMLGEOX_VERSION latest
+ENV ETF_GMLGEOX_VERSION 1.2.2-SNAPSHOT
 
-# Possible values: “latest”, <version as MAJOR.MINOR.BUGFIX> or
-# <version as MAJOR.MINOR>
 # Packed with the Webapp
-ENV ETF_TESTDRIVER_SUI_VERSION latest
+ENV ETF_TESTDRIVER_SUI_VERSION 2.0.1-SNAPSHOT
 
-# Possible values: “latest”, <version as MAJOR.MINOR.BUGFIX> or
-# <version as MAJOR.MINOR>
 # Packed with the Webapp
-ENV ETF_TESTDRIVER_TE_VERSION latest
+ENV ETF_TESTDRIVER_TE_VERSION 1.0.1-SNAPSHOT
 
 # Default repository configuration (where software artifacts are downloaded from)
-ENV REPO_URL https://services.interactive-instruments.de/etfdev-af/etf-public-dev
-ENV REPO_USER etf-public-dev
-ENV REPO_PWD etf-public-dev
+ENV REPO_URL http://build-artifacts.wetransform.to.s3-eu-central-1.amazonaws.com/travisci/etf-public-dev
 
 #
 # Runtime configuration

--- a/res/docker-init.sh
+++ b/res/docker-init.sh
@@ -86,7 +86,7 @@ fi
 # Download Webapp
 if [ ! -f "$appServerDeplPath/$ETF_RELATIVE_URL".war ]; then
     echo "Downloading ETF. This may take a while..."
-    get de/interactive_instruments/etf/etf-webapp etf-webapp-[0-9\.]+.war "$ETF_WEBAPP_VERSION" "$appServerDeplPath/$ETF_RELATIVE_URL".war
+    getFrom ${REPO_URL}/de/interactive_instruments/etf/etf-webapp/etf-webapp-${ETF_WEBAPP_VERSION}.war "$appServerDeplPath/$ETF_RELATIVE_URL".war
 fi
 
 # Download BaseX test driver
@@ -95,14 +95,14 @@ if [[ -n "$ETF_TESTDRIVER_BSX_VERSION" && "$ETF_TESTDRIVER_BSX_VERSION" != "none
     echo "Using existing BSX test driver, skipping download"
   else
     echo "Downloading BSX test driver"
-    get de/interactive_instruments/etf/testdriver/etf-bsxtd/ etf-bsxtd-[0-9\.]+.jar "$ETF_TESTDRIVER_BSX_VERSION" /tmp/etf-bsxtd.jar
+    getFrom ${REPO_URL}/de/interactive_instruments/etf/testdriver/etf-bsxtd/etf-bsxtd-${ETF_TESTDRIVER_BSX_VERSION}.jar /tmp/etf-bsxtd.jar
     mv /tmp/etf-bsxtd.jar "$ETF_DIR"/td
   fi
 fi
 
 # Download GmlGeoX
 if [[ ! -f "$ETF_DIR"/ds/db/repo/de/interactive_instruments/etf/bsxm/GmlGeoX.jar && -n "$ETF_GMLGEOX_VERSION" && "$ETF_GMLGEOX_VERSION" != "none" ]]; then
-  get de/interactive_instruments/etf/bsxm/etf-gmlgeox/ etf-gmlgeox-[0-9\.]+.jar "$ETF_GMLGEOX_VERSION" /tmp/GmlGeoX.jar
+  getFrom ${REPO_URL}/de/interactive_instruments/etf/testdriver/etf-gmlgeox/etf-gmlgeox-${ETF_GMLGEOX_VERSION}.jar /tmp/GmlGeoX.jar
   mkdir -p "$ETF_DIR"/ds/db/repo/de/interactive_instruments/etf/bsxm/
   mv /tmp/GmlGeoX.jar "$ETF_DIR"/ds/db/repo/de/interactive_instruments/etf/bsxm/
 fi
@@ -113,7 +113,7 @@ if [[ -n "$ETF_TESTDRIVER_SUI_VERSION" && "$ETF_TESTDRIVER_SUI_VERSION" != "none
     echo "Using existing SUI test driver, skipping download"
   else
     echo "Downloading SUI test driver"
-    get de/interactive_instruments/etf/testdriver/etf-suitd/ etf-suitd-[0-9\.]+.jar "$ETF_TESTDRIVER_SUI_VERSION" /tmp/etf-suitd.jar
+    getFrom ${REPO_URL}/de/interactive_instruments/etf/testdriver/etf-suitd/etf-suitd-${ETF_TESTDRIVER_SUI_VERSION}.jar /tmp/etf-suitd.jar
     mv /tmp/etf-suitd.jar "$ETF_DIR"/td
   fi
 fi
@@ -124,7 +124,7 @@ if [[ -n "$ETF_TESTDRIVER_TE_VERSION" && "$ETF_TESTDRIVER_TE_VERSION" != "none" 
     echo "Using existing TE test driver, skipping download"
   else
     echo "Downloading TE test driver"
-    get de/interactive_instruments/etf/testdriver/etf-tetd/ etf-tetd-[0-9\.]+.jar "$ETF_TESTDRIVER_TE_VERSION" /tmp/etf-tetd.jar
+    getFrom ${REPO_URL}/de/interactive_instruments/etf/testdriver/etf-tetd/etf-tetd-${ETF_TESTDRIVER_TE_VERSION}.jar /tmp/etf-tetd.jar
     mv /tmp/etf-tetd.jar "$ETF_DIR"/td
   fi
 fi


### PR DESCRIPTION
ETF artifacts are downloaded from the `build-artifacts` S3 bucket.
The versions are now fixed as the "latest" mechanism in
`res/docker-init.sh` does not work with S3 buckets.

ING-426